### PR TITLE
Rewrite comparator for CSS property sort optimization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -423,11 +423,21 @@ function compareHyphenCount(a, b) {
 	const isCustom = (name) => /^--\b/.test(name);
 	const isVendored = (name) => /^-\b/.test(name);
 
-	return (
-		(isCustom(a) & !isCustom(b)) * 0b1000000 |
-		(isVendored(a) & !isVendored(b)) * 0b0100000 |
-		Math.min(b.split('-').length - a.split('-').length, 0b0011111)
-	);
+	if (isCustom(a) && !isCustom(b)) {
+		return 1;
+	}
+	if (!isCustom(a) && isCustom(b)) {
+		return -1;
+	}
+
+	if (isVendored(a) && !isVendored(b)) {
+		return 1;
+	}
+	if (!isVendored(a) && isVendored(b)) {
+		return -1;
+	}
+
+	return b.split('-').length - a.split('-').length;
 }
 
 /**


### PR DESCRIPTION
Rewrite the `compareHyphenCount` function in order to obey the [algorithmic rules of `Array.sort` comparators][mdn-array-sort-comparator].

Previously the function was not sorting properties because it was not anti-symmetric or transitive.

NB: This supersedes #4.

[mdn-array-sort-comparator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#:~:text=More%20formally%2C%20the%20comparator